### PR TITLE
Profile search

### DIFF
--- a/components/ProfileSearchBar.tsx
+++ b/components/ProfileSearchBar.tsx
@@ -1,0 +1,41 @@
+import { useState, useEffect } from "react";
+import baseUrl from "../utils/baseUrl";
+import { Flex } from "@chakra-ui/react";
+import Router from "next/router";
+
+export default function ProfileSearchBar() {
+    
+    const [search, updateSearch] = useState("");
+    const [query, setQuery] = useState([]);
+
+    useEffect(() => {
+        async function handler() {
+            setQuery(
+                await fetch(`${baseUrl}/api/users/search/${search}`, {
+                    method: 'GET'
+                })
+                    .then((response) => response.json())
+                    .then((users) => {
+                        return users.data;
+                })
+            );
+        }
+        handler();
+    }, [search]);
+
+    return (
+        <>
+            <input type="text" value={search} onChange={(event) => {
+                updateSearch(event.target.value);
+            }} />
+            {query?.map((user) => (
+                <Flex onClick={() => Router.push(`${baseUrl}/profile/${user.userName}`)}>
+                    <img src={user.profilePicture} />
+                    <p>{user.userName}</p>
+                    <p>{user.firstName}</p>
+                    <p>{user.lastName}</p>
+                </Flex>
+            ))}
+        </>
+    );
+}

--- a/pages/api/users/search.ts
+++ b/pages/api/users/search.ts
@@ -1,0 +1,43 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { verifyIdToken } from "next-firebase-auth";
+
+import type { User } from "../../../types/models";
+import dbConnect from "../../../utils/dbConnect";
+import UserModel from "../../../models/User";
+
+type Data = {
+  success: boolean;
+  data?: User;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Data>
+) {
+  const { method } = req;
+
+  if (method === "GET") {
+    await dbConnect();
+
+    try {
+    
+      var users = await UserModel.find({
+          "$or": [
+              {
+                  userName: req.body.query
+              },
+              {
+                  firstName: req.body.query
+              },
+              {
+                  lastName: req.body.query
+              }
+          ]
+      });
+      if (!users) throw new Error("Data not found");
+      return res.status(200).json({ success: true, users: users });
+    } catch (error) {
+      return res.status(400).json({ success: false });
+    }
+  } else return res.status(500).json({ success: false });
+}

--- a/pages/api/users/search.ts
+++ b/pages/api/users/search.ts
@@ -7,7 +7,7 @@ import UserModel from "../../../models/User";
 
 type Data = {
   success: boolean;
-  data?: User;
+  data?: User[];
 };
 
 export default async function handler(
@@ -35,7 +35,7 @@ export default async function handler(
           ]
       });
       if (!users) throw new Error("Data not found");
-      return res.status(200).json({ success: true, users: users });
+      return res.status(200).json({ success: true, data: users });
     } catch (error) {
       return res.status(400).json({ success: false });
     }

--- a/pages/api/users/search/[query].ts
+++ b/pages/api/users/search/[query].ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { verifyIdToken } from "next-firebase-auth";
 
-import type { User } from "../../../types/models";
-import dbConnect from "../../../utils/dbConnect";
-import UserModel from "../../../models/User";
+import type { User } from "../../../../types/models";
+import dbConnect from "../../../../utils/dbConnect";
+import UserModel from "../../../../models/User";
 
 type Data = {
   success: boolean;
@@ -14,23 +14,34 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<Data>
 ) {
-  const { method } = req;
+
+  const method = req.method;
+  const queryBody = req.query;
+  const query_string = queryBody.query;
 
   if (method === "GET") {
     await dbConnect();
-
     try {
     
       var users = await UserModel.find({
           "$or": [
               {
-                  userName: req.body.query
+                  userName: {
+                    "$regex": query_string,
+                    "$options": "i"
+                  }
               },
               {
-                  firstName: req.body.query
+                  firstName: {
+                    "$regex": query_string,
+                    "$options": "i"
+                  }
               },
               {
-                  lastName: req.body.query
+                  lastName: {
+                    "$regex": query_string,
+                    "$options": "i"
+                  }
               }
           ]
       });


### PR DESCRIPTION
Added profile search feature, including an API route to search for users by providing a string that is compared across usernames, first names, and last names. Furthermore, a basic template for a custom profile search bar was created, which includes a text box for the user to type their query name, and will display a list of users with regex-matching names appropriately. The displayed profiles redirect to the corresponding profiles when clicked. Styling has not been done for the profile search bar.

Added files:
- `components/ProfileSearchBar.tsx`
- `pages/api/users/search/[query].ts`